### PR TITLE
Add shebang and gitignore

### DIFF
--- a/printNumbers/.gitignore
+++ b/printNumbers/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*/__pycache__/

--- a/printNumbers/printNumbers.py
+++ b/printNumbers/printNumbers.py
@@ -1,3 +1,4 @@
+#! /bin/env python
 # -*- coding: utf-8 -*-
 #
 # printNumbers.py


### PR DESCRIPTION
Add shebang to make the script executable by calling `./printNumbers.py`.
Add `.gitignore` to ignore pycache directories.